### PR TITLE
add postgres-prometheus as supported backend

### DIFF
--- a/cachalot/settings.py
+++ b/cachalot/settings.py
@@ -6,6 +6,7 @@ SUPPORTED_DATABASE_ENGINES = {
     'django.db.backends.sqlite3',
     'django.db.backends.postgresql',
     'django.db.backends.mysql',
+    'django_prometheus.db.backends.postgresql',
     # TODO: Remove when we drop Django 2.x support.
     'django.db.backends.postgresql_psycopg2',
 


### PR DESCRIPTION
Django Prometheus DB is just a wrapper around Postgres DB:
https://github.com/korfuri/django-prometheus/blob/master/django_prometheus/db/backends/postgresql/base.py

I tried and it seems to be working fine

Signed-off-by: Jordan Jacobelli <jordan@cri.epita.net>