### PR TITLE
Allow databases to use the same table cache key.

### DIFF
--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -33,6 +33,7 @@ CACHABLE_PARAM_TYPES = {
 }
 CACHABLE_PARAM_TYPES.update(integer_types)  # Adds long for Python 2
 UNCACHABLE_FUNCS = {Now, TransactionNow}
+OVERRIDE_DB_ALIAS_KEY = 'CACHE_KEY'
 
 try:
     from psycopg2 import Binary
@@ -91,6 +92,8 @@ def get_table_cache_key(db_alias, table):
     :return: A cache key
     :rtype: int
     """
+    if OVERRIDE_DB_ALIAS_KEY in cachalot_settings.DATABASES[db_alias]:
+        db_alias = cachalot_settings.DATABASES[db_alias][OVERRIDE_DB_ALIAS_KEY]
     cache_key = '%s:%s' % (db_alias, table)
     return sha1(cache_key.encode('utf-8')).hexdigest()
 


### PR DESCRIPTION
This would allow us to link master-replica databases like this:

    DATABASES = {
        'master': {
            'CACHE_KEY': 'WE_ARE_ONE',
            'ENGINE': 'django.db.backends.postgresql_psycopg2',
            'NAME': DB_NAME,
            'USER': DB_USER,
            'PASSWORD': DB_PASSWORD,
            'HOST': DB_HOST,
            'PORT': DB_PORT,
            'OPTIONS': {
                'client_encoding': "UTF8"
            }
        },
        'replica' : {
            'CACHE_KEY': 'WE_ARE_ONE',
            'ENGINE': 'django.db.backends.postgresql_psycopg2',
            'NAME': DB_NAME,
            'USER': DB_USER,
            'PASSWORD': DB_PASSWORD,
            'HOST': DB_HOST,
            'PORT': DB_PORT,
            'OPTIONS': {
                'client_encoding': "UTF8"
            }
        }
    }