### PR TITLE
add django-prometheus wrapped database engines to the list of supported db engines

### DIFF
--- a/cachalot/settings.py
+++ b/cachalot/settings.py
@@ -20,6 +20,11 @@ SUPPORTED_DATABASE_ENGINES = {
     # TODO: Remove when we drop Django 2.x support.
     'transaction_hooks.backends.postgresql_psycopg2',
     'transaction_hooks.backends.mysql',
+
+    # django-prometheus wrapped engines
+    'django_prometheus.db.backends.sqlite3',
+    'django_prometheus.db.backends.postgresql',
+    'django_prometheus.db.backends.mysql',
 }
 
 SUPPORTED_CACHE_BACKENDS = {


### PR DESCRIPTION
[//]: # (Thanks for helping us out! Cache invalidation sucks, so your help is greatly appreciated!)

## Description

This patch adds support for MySQL, PostgreSQL and SQLite3 engines wrapped for use with django-prometheus (https://github.com/korfuri/django-prometheus).
It simply adds those engines into the list of supported ones.

[//]: # (What're you proposing?)


## Rationale

I added Prometheus support into my Django project and was scratching my head for quite some time to find out why django-cachalot stopped working. This patch fixes it for me and potentially other users.

[//]: # (Why should we implement it?)
