### PR TITLE
Make it possible to disable cachalot on per-query basis

### DIFF
--- a/cachalot/monkey_patch.py
+++ b/cachalot/monkey_patch.py
@@ -66,6 +66,9 @@ def _patch_compiler(original):
     @_unset_raw_connection
     def inner(compiler, *args, **kwargs):
         execute_query_func = lambda: original(compiler, *args, **kwargs)
+        if compiler.query and getattr(compiler.query, 'cachalot_do_not_cache', False):
+            return execute_query_func()
+
         db_alias = compiler.using
         if db_alias not in cachalot_settings.CACHALOT_DATABASES \
                 or isinstance(compiler, WRITE_COMPILERS):

--- a/cachalot/tests/read.py
+++ b/cachalot/tests/read.py
@@ -862,6 +862,32 @@ class ReadTestCase(TestUtilsMixin, TransactionTestCase):
         self.assert_tables(qs, UnmanagedModel)
         self.assert_query_cached(qs)
 
+    def test_per_query_do_not_cache_uncached_data(self):
+        """
+        Test that when a query is given the `cachalot_do_not_cache` attribute with True value,
+        the query will not be cached.
+        """
+        qs = Test.objects.all()
+        qs.query.cachalot_do_not_cache = True
+        with self.assertNumQueries(1):
+            data1 = list(qs.all())
+        with self.assertNumQueries(1):
+            # repeat run of the same query should trigger one more DB query
+            data2 = list(qs.all())
+        self.assertEqual(data1, data2)
+
+    def test_per_query_do_not_cache_cached_data(self):
+        """
+        Test that when a query is given the `cachalot_do_not_cache` attribute with True value,
+        the query will not be cached and a query will be performed even if the data is already
+        cached
+        """
+        qs = Test.objects.all()
+        self.assert_query_cached(qs)
+        qs.query.cachalot_do_not_cache = True
+        with self.assertNumQueries(1):
+            list(qs.all())
+
 
 class ParameterTypeTestCase(TestUtilsMixin, TransactionTestCase):
     def test_tuple(self):


### PR DESCRIPTION
[//]: # (Thanks for helping us out! Cache invalidation sucks, so your help is greatly appreciated!)

## Description

This patch makes it possible to disable caching on per-cache basis by settings the attribute `cachalot_do_not_cache` to True on the query.

[//]: # (What're you proposing?)


## Rationale

Sometimes the programmer knows that a query will return a large response which will not be reused (in our case it is an export which can have hundreds of megabytes of data, which is streamed by chunk directly into a compressed file). This can potentially lead even to memory errors when the maximum size of the cache is reached (this is exactly what we see with our Redis cache).
In such cases, it would be great to be able to mark a specific query as excluded from caching which would save the work required to store it and also prevent possible memory errors.
The method I implemented here is not super-nice, but it is simple and works with minimum changes to the Cachalot source code.

[//]: # (Why should we implement it?)
