### PR TITLE
Add support for disabling cachalot

### DIFF
--- a/cachalot/api.py
+++ b/cachalot/api.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from django.apps import apps
 from django.conf import settings
 from django.db import connections
@@ -9,7 +11,15 @@ from .transaction import AtomicCache
 from .utils import _invalidate_tables
 
 
-__all__ = ('invalidate', 'get_last_invalidation')
+try:
+    from asgiref.local import Local
+    LOCAL_STORAGE = Local()
+except ImportError:
+    import threading
+    LOCAL_STORAGE = threading.local()
+
+
+__all__ = ('invalidate', 'get_last_invalidation', 'cachalot_disabled')
 
 
 def _cache_db_tables_iterator(tables, cache_alias, db_alias):
@@ -121,3 +131,28 @@ def get_last_invalidation(*tables_or_models, **kwargs):
             if current_last_invalidation > last_invalidation:
                 last_invalidation = current_last_invalidation
     return last_invalidation
+
+
+@contextmanager
+def cachalot_disabled():
+    """
+    Context manager for temporarily disabling cachalot.
+    If you evaluate the same queryset a second time,
+    like normally for Django querysets, this will access
+    the variable that saved it in-memory.
+
+    For example:
+    qs = Test.objects.filter(blah=blah)
+    with cachalot_disabled():
+        # Does a single query to the db
+        list(qs)  # Evaluates queryset
+        # Because the qs was evaluated, it's
+        # saved in memory. Does 0 queries.
+        list(qs)
+        # Does 1 query to the db
+        list(Test.objects.filter(blah=blah))
+    """
+    was_enabled = getattr(LOCAL_STORAGE, "cachalot_enabled", cachalot_settings.CACHALOT_ENABLED)
+    LOCAL_STORAGE.enabled = False
+    yield
+    LOCAL_STORAGE.enabled = was_enabled

--- a/cachalot/tests/read.py
+++ b/cachalot/tests/read.py
@@ -18,6 +18,7 @@ from django.test import (
 from pytz import UTC
 
 from cachalot.cache import cachalot_caches
+from ..api import cachalot_disabled
 from ..settings import cachalot_settings
 from ..utils import UncachableQuery
 from .models import Test, TestChild, TestParent, UnmanagedModel
@@ -861,6 +862,17 @@ class ReadTestCase(TestUtilsMixin, TransactionTestCase):
         qs = UnmanagedModel.objects.all()
         self.assert_tables(qs, UnmanagedModel)
         self.assert_query_cached(qs)
+
+    def test_query_cachalot_disabled_even_if_already_cached(self):
+        """
+        Test that when a query is given the `cachalot_disabled` context manager,
+        the query will not be cached and a query will be performed even if the
+        data is already cached
+        """
+        qs = Test.objects.all()
+        self.assert_query_cached(qs)
+        with cachalot_disabled() and self.assertNumQueries(1):
+            list(qs.all())
 
 
 class ParameterTypeTestCase(TestUtilsMixin, TransactionTestCase):


### PR DESCRIPTION
## Description

This context manager allows for disabling cachalot using a context manager

Description:

Context manager for temporarily disabling cachalot. If you evaluate the same queryset a second time, like normally for Django querysets, this will access the variable that saved it in-memory.

For example:

    qs = Test.objects.filter(blah=blah)
    with cachalot_disabled():
        # Does a single query to the db
        list(qs)  # Evaluates queryset
        # Because the qs was evaluated, it's
        # saved in memory. Does 0 queries.
        list(qs)
        # Does 1 query to the db
        list(Test.objects.filter(blah=blah))

It's not time to write some async context manager, but because some people, like me, who use ASGI a lot for websockets, I've defaulted threading.local to asgiref.local.Local if asgiref is available (yes if Django 3.0, but because Django 2.2 is LTS, there must be this try except).

## Rationale

As @beda42 said:
> Sometimes the programmer knows that a query will return a large response which will not be reused (in our case it is an export which can have hundreds of megabytes of data, which is streamed by chunk directly into a compressed file). This can potentially lead even to memory errors when the maximum size of the cache is reached (this is exactly what we see with our Redis cache).

Also, for the reasoning behind that above example code: https://github.com/noripyt/django-cachalot/pull/155#discussion_r452563882