### PR TITLE
Fix warning regarding ABC import from collections

### DIFF
--- a/cachalot/monkey_patch.py
+++ b/cachalot/monkey_patch.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 from functools import wraps
 from time import time
 


### PR DESCRIPTION
## Description

Import ABC from collections.abc

## Rationale

Fixes #159 and improves Python 3 compatibility.