### PR TITLE
Cast memoryview objects to bytes to be able to pickle them.

### DIFF
--- a/cachalot/apps.py
+++ b/cachalot/apps.py
@@ -1,3 +1,4 @@
+import copyreg
 from django import __version__ as django__version__, VERSION as django_version
 from django.apps import AppConfig
 from django.conf import settings
@@ -93,4 +94,7 @@ class CachalotConfig(AppConfig):
     name = 'cachalot'
 
     def ready(self):
+        # Cast memoryview objects to bytes to be able to pickle them.
+        # https://docs.python.org/3/library/copyreg.html#copyreg.pickle
+        copyreg.pickle(memoryview, lambda val: (memoryview, (bytes(val),)))
         cachalot_settings.load()


### PR DESCRIPTION
## Description
To fix issue #125, copyreg can be used to define how memoryview objects should be pickled. 

## Rationale
This allows caching of fields like LineStringField and other GIS-fields and prevents crashes with "Can't pickle memoryview objects".
