### PR TITLE
Remove deprecated argument

### DIFF
--- a/cachalot/signals.py
+++ b/cachalot/signals.py
@@ -1,4 +1,5 @@
 from django.dispatch import Signal
 
-
-post_invalidation = Signal(providing_args=['db_alias'])
+# The argument "providing_args=['db_alias']" is deprecated and purely documentational.
+# TODO: Write a explaining text to what "db_alias" is supposed to document.
+post_invalidation = Signal()

--- a/cachalot/signals.py
+++ b/cachalot/signals.py
@@ -1,5 +1,5 @@
 from django.dispatch import Signal
 
-# The argument "providing_args=['db_alias']" is deprecated and purely documentational.
-# TODO: Write a explaining text to what "db_alias" is supposed to document.
+# sender: name of table invalidated
+# db_alias: name of database that was effected
 post_invalidation = Signal()


### PR DESCRIPTION
## Description
When running a project with this package as dependency, I'm getting the following warning message.

```
RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.
```

## Rationale
By moving the argument to a comment it will not pollute the logs when developing in other projects.

