### PR TITLE
Adds django_db_geventpool.backends.postgresql_psycopg2 as supported database

### DIFF
--- a/cachalot/settings.py
+++ b/cachalot/settings.py
@@ -8,6 +8,7 @@ SUPPORTED_DATABASE_ENGINES = {
     'django.db.backends.mysql',
     # TODO: Remove when we drop Django 2.x support.
     'django.db.backends.postgresql_psycopg2',
+    'django_db_geventpool.backends.postgresql_psycopg2',
 
     # GeoDjango
     'django.contrib.gis.db.backends.spatialite',


### PR DESCRIPTION
[//]: # (Thanks for helping us out! Cache invalidation sucks, so your help is greatly appreciated!)

## Description

We've been using `django-cachalot` in a production environment for a while and after questioning about that on the Slack help page, it was recommended the addition of `django_db_geventpool.backends.postgresql_psycopg2` as a supported database.

[//]: # (What're you proposing?)

Adding `django_db_geventpool.backends.postgresql_psycopg2` as supported database.

## Rationale

I'm not sure how to add a test for it but it's being used for at least 5 months in a production environment.

[//]: # (Why should we implement it?)

It would remove the warning from deployments using the `django_db_geventpool`.