### PR TITLE
Also support django_prpmetheus wrapped caches

### DIFF
--- a/cachalot/settings.py
+++ b/cachalot/settings.py
@@ -34,6 +34,12 @@ SUPPORTED_CACHE_BACKENDS = {
     'django_redis.cache.RedisCache',
     'django.core.cache.backends.memcached.MemcachedCache',
     'django.core.cache.backends.memcached.PyLibMCCache',
+
+    # django-prometheus wrapped backends
+    'django_prometheus.cache.backends.locmem.LocMemCache',
+    'django_prometheus.cache.backends.filebased.FileBasedCache',
+    'django_prometheus.cache.backends.memcached.MemcachedCache',
+    'django_prometheus.cache.backends.redis.RedisCache',
 }
 
 SUPPORTED_ONLY = 'supported_only'


### PR DESCRIPTION
## Description

Add the cache backends wrapped by django_prometheus as supported backends.

## Rationale

cachalot already explicitly supports django_prometheus' wrappers for database backends. djanfo_prometheus does the same wrapping for cache backends, so they should be supported as well.