### PR TITLE
Do not throw exception on externally invalidated cache keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 What’s new in django-cachalot?
 ==============================
 
+2.3.4
+-----
+
+- Fix bug with externally invalidated cache keys (#120)
+
 2.3.3
 -----
 


### PR DESCRIPTION
[//]: # (Thanks for helping us out! Cache invalidation sucks, so your help is greatly appreciated!)

## Description

[//]: # (What're you proposing?)

This PR fixes the issue described in #120 by catching KeyErrors on cache retrieval after restarts.
