### PR TITLE
Fix cachalot_disabled

### DIFF
--- a/cachalot/api.py
+++ b/cachalot/api.py
@@ -161,7 +161,7 @@ def cachalot_disabled(all_queries=False):
     :type all_queries: bool
     """
     was_enabled = getattr(LOCAL_STORAGE, "cachalot_enabled", cachalot_settings.CACHALOT_ENABLED)
-    LOCAL_STORAGE.enabled = False
+    LOCAL_STORAGE.cachalot_enabled = False
     LOCAL_STORAGE.disable_on_all = all_queries
     yield
-    LOCAL_STORAGE.enabled = was_enabled
+    LOCAL_STORAGE.cachalot_enabled = was_enabled


### PR DESCRIPTION
## Description
cachalot_disabled is not working.


## Rationale

unused varialbe LOCAL_STORAGE.enabled was configured
instead of LOCAL_STORAGE.cachalot_enabled which is later used
to turn off the caching

