### PR TITLE
Add SUPPORTED_DATABASE_ENGINES & SUPPORTED_CACHE_BACKENDS (Fixes #131)

### DIFF
--- a/cachalot/apps.py
+++ b/cachalot/apps.py
@@ -17,8 +17,7 @@ def check_cache_compatibility(app_configs, **kwargs):
         return [Warning(
             'Cache backend %r is not supported by django-cachalot.'
             % cache_backend,
-            hint='Switch to a supported cache backend '
-                 'like Redis or Memcached.',
+            hint='Switch to a supported cache backend like Redis or Memcached.',
             id='cachalot.W001')]
     return []
 
@@ -27,8 +26,7 @@ def check_cache_compatibility(app_configs, **kwargs):
 def check_databases_compatibility(app_configs, **kwargs):
     errors = []
     databases = settings.DATABASES
-    original_enabled_databases = getattr(settings, 'CACHALOT_DATABASES',
-                                         SUPPORTED_ONLY)
+    original_enabled_databases = getattr(settings, 'CACHALOT_DATABASES', SUPPORTED_ONLY)
     enabled_databases = cachalot_settings.CACHALOT_DATABASES
     if original_enabled_databases == SUPPORTED_ONLY:
         if not cachalot_settings.CACHALOT_DATABASES:

--- a/cachalot/settings.py
+++ b/cachalot/settings.py
@@ -13,25 +13,13 @@ SUPPORTED_DATABASE_ENGINES = {
     'django.contrib.gis.db.backends.spatialite',
     'django.contrib.gis.db.backends.postgis',
     'django.contrib.gis.db.backends.mysql',
-
-    # django-transaction-hooks
-    'transaction_hooks.backends.sqlite3',
-    'transaction_hooks.backends.postgis',
-    # TODO: Remove when we drop Django 2.x support.
-    'transaction_hooks.backends.postgresql_psycopg2',
-    'transaction_hooks.backends.mysql',
-
-    # django-prometheus wrapped engines
-    'django_prometheus.db.backends.sqlite3',
-    'django_prometheus.db.backends.postgresql',
-    'django_prometheus.db.backends.mysql',
 }
 
 SUPPORTED_CACHE_BACKENDS = {
     'django.core.cache.backends.dummy.DummyCache',
     'django.core.cache.backends.locmem.LocMemCache',
     'django.core.cache.backends.filebased.FileBasedCache',
-    'django_redis.cache.RedisCache',
+    'django_redis.cache.RedisCache',  # Even though it's not from Django, we do test it
     'django.core.cache.backends.memcached.MemcachedCache',
     'django.core.cache.backends.memcached.PyLibMCCache',
     'django.core.cache.backends.memcached.PyMemcacheCache',
@@ -41,13 +29,15 @@ SUPPORTED_ONLY = 'supported_only'
 ITERABLES = {tuple, list, frozenset, set}
 
 
-class Settings(object):
+class Settings:
     patched = False
     converters = {}
 
     CACHALOT_ENABLED = True
     CACHALOT_CACHE = 'default'
     CACHALOT_DATABASES = 'supported_only'
+    CACHALOT_SUPPORTED_DATABASE_ENGINES = {}
+    CACHALOT_SUPPORTED_CACHE_BACKENDS = {}
     CACHALOT_TIMEOUT = None
     CACHALOT_CACHE_RANDOM = False
     CACHALOT_INVALIDATE_RAW = True
@@ -76,6 +66,13 @@ class Settings(object):
             if converter is not None:
                 value = converter(value)
             setattr(self, name, value)
+
+        SUPPORTED_DATABASE_ENGINES.update(
+            getattr(settings, "CACHALOT_SUPPORTED_DATABASE_ENGINES", {})
+        )
+        SUPPORTED_CACHE_BACKENDS.update(
+            getattr(settings, "CACHALOT_SUPPORTED_CACHE_BACKENDS", {})
+        )
 
         if not self.patched:
             from .monkey_patch import patch

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -82,6 +82,34 @@ Settings
 .. |DATABASES| replace:: ``DATABASES``
 .. _DATABASES: https://docs.djangoproject.com/en/2.0/ref/settings/#std:setting-DATABASES
 
+``CACHALOT_SUPPORTED_DATABASE_ENGINES``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Default: ``{}``
+:Description:
+  Sequence of (string) database engines to add to the currently supported set.
+  This does not override the supported set, only appends.
+
+  .. warning::
+     Use at your own risk. Before just adding your engine, test it via a PR, fork,
+     or in your current Django project via our test suite. The GitHub action shows
+     how to add a Docker image to properly utilize the test suite. Not all Django
+     database engines are included such as MariaDB and Oracle. Check the supported ones
+     out in the settings.py file.
+
+``CACHALOT_SUPPORTED_CACHE_BACKENDS``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Default: ``{}``
+:Description:
+  Sequence of (string) cache backends to add to the currently supported set.
+  This does not override the supported set, only appends.
+
+  .. warning::
+     Use at your own risk. Before just adding your engine, test it via a PR, fork,
+     or in your current Django project via our test suite. The GitHub action shows
+     how to add a Docker image to properly utilize the test suite.
+
 ``CACHALOT_TIMEOUT``
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Description

Fixes #131

* Drop django-transaction-hooks and django-prometheus projects in favor of using these settings

## Rationale

Greater flexibility for those who want inheritance or have a separate project that has some form of support.