### PR TITLE
Drop Django 3.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9']
-        django-version: ['2.2', '3.0', '3.1', '3.2']
+        django-version: ['2.2', '3.1', '3.2']
 
     services:
       redis:

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Table of Contents:
 Quickstart
 ----------
 
-Cachalot officially supports Python 3.6-3.9 and Django 2.2 and 3.0-3.2 with the databases PostgreSQL, SQLite, and MySQL.
+Cachalot officially supports Python 3.6-3.9 and Django 2.2 and 3.1-3.2 with the databases PostgreSQL, SQLite, and MySQL.
 
 Note: an upper limit on Django version is set for your safety. Please do not ignore it.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,8 +4,8 @@ Quick start
 Requirements
 ............
 
-- Django 2.0-2.2, 3.0-3.1
-- Python 3.5-3.9
+- Django 2.2, 3.1-3.2
+- Python 3.6-3.9
 - a cache configured as ``'default'`` with one of these backends:
 
   - `django-redis <https://github.com/niwinz/django-redis>`_
@@ -67,7 +67,7 @@ Settings
      change this setting, you end up on a cache that may contain stale data.
 
 .. |CACHES| replace:: ``CACHES``
-.. _CACHES: https://docs.djangoproject.com/en/2.0/ref/settings/#std:setting-CACHES
+.. _CACHES: https://docs.djangoproject.com/en/dev/ref/settings/#caches
 
 ``CACHALOT_DATABASES``
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -80,7 +80,7 @@ Settings
   engines.
 
 .. |DATABASES| replace:: ``DATABASES``
-.. _DATABASES: https://docs.djangoproject.com/en/2.0/ref/settings/#std:setting-DATABASES
+.. _DATABASES: https://docs.djangoproject.com/en/dev/ref/settings/#databases
 
 ``CACHALOT_TIMEOUT``
 ~~~~~~~~~~~~~~~~~~~~
@@ -201,7 +201,7 @@ Examples:
 Template utils
 ..............
 
-`Caching template fragments <https://docs.djangoproject.com/en/2.0/topics/cache/#template-fragment-caching>`_
+`Caching template fragments <https://docs.djangoproject.com/en/dev/topics/cache/#template-fragment-caching>`_
 can be extremely powerful to speedup a Django application.  However, it often
 means you have to adapt your models to get a relevant cache key, typically
 by adding a timestamp that refers to the last modification of the object.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Programming Language :: Python :: 3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py{36,37,38,39}-django2.2-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
-    py{36,37,38,39}-django3.0-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
     py{36,37,38,39}-django3.1-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
     py{36,37,38,39}-django3.2-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
 
@@ -13,7 +12,6 @@ basepython =
     py39: python3.9
 deps =
     django2.2: Django>=2.2,<2.3
-    django3.0: Django>=3.0,<3.1
     django3.1: Django>=3.1,<3.2
     django3.2: Django>=3.2,<3.3
     psycopg2-binary
@@ -47,6 +45,5 @@ PYTHON_VER =
     3.9: py39
 DJANGO =
     2.2: django2.2
-    3.0: django3.0
     3.1: django3.1
     3.2: django3.2


### PR DESCRIPTION
## Description

Drop Django 3.0 support

## Rationale

* Extended support for Django 3.0 was ended on April 6, 2021
