### PR TITLE
Check for Uncachables (i.e. Now) in annotations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 What’s new in django-cachalot?
 ==============================
 
+2.4.3
+-----
+
+- Fix annotated Now being cached (#195)
+- Fix conditional annotated expressions not being cached (#196)
+
 2.4.2
 -----
 

--- a/cachalot/tests/read.py
+++ b/cachalot/tests/read.py
@@ -873,6 +873,11 @@ class ReadTestCase(TestUtilsMixin, TransactionTestCase):
         self.assert_tables(qs, UnmanagedModel)
         self.assert_query_cached(qs)
 
+    def test_now_annotate(self):
+        """Check that queries with a Now() annotation are not cached #193"""
+        qs = Test.objects.annotate(now=Now())
+        self.assert_query_cached(qs, after=1)
+        
 
 class ParameterTypeTestCase(TestUtilsMixin, TransactionTestCase):
     def test_tuple(self):

--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -178,6 +178,8 @@ def _get_tables(db_alias, query):
                     tables.update(_get_tables(db_alias, annotation.queryset.query))
                 else:
                     tables.update(_get_tables(db_alias, annotation.query))
+            elif type(annotation) in UNCACHABLE_FUNCS:
+                raise UncachableQuery
         # Gets tables in WHERE subqueries.
         for subquery in _find_subqueries_in_where(query.where.children):
             tables.update(_get_tables(db_alias, subquery))


### PR DESCRIPTION
Fixes #193 

Ignore the PostgreSQL test cases. That is due to the psycopg2 package itself which is incompatible with Django 2.2.