### PR TITLE
Simplify annotation handling by using the flatten method:

### DIFF
--- a/cachalot/tests/read.py
+++ b/cachalot/tests/read.py
@@ -405,6 +405,14 @@ class ReadTestCase(TestUtilsMixin, TransactionTestCase):
         self.assert_tables(qs, User, Test)
         self.assert_query_cached(qs, [self.user, self.admin])
 
+    def test_annotate_raw(self):
+        qs = User.objects.annotate(
+            perm_id=RawSQL('SELECT id FROM auth_permission WHERE id = %s',
+                           (self.t1__permission.pk,))
+        )
+        self.assert_tables(qs, User, Permission)
+        self.assert_query_cached(qs, [self.user, self.admin])
+
     def test_only(self):
         with self.assertNumQueries(1):
             t1 = Test.objects.only('name').first()

--- a/cachalot/tests/read.py
+++ b/cachalot/tests/read.py
@@ -372,12 +372,23 @@ class ReadTestCase(TestUtilsMixin, TransactionTestCase):
         self.assert_tables(qs, User, Test)
         self.assert_query_cached(qs, [self.user, self.admin])
 
-    def test_annotate_case_with_when(self):
+    def test_annotate_case_with_when_and_query_in_default(self):
         tests = Test.objects.filter(owner=OuterRef('pk')).values('name')
         qs = User.objects.annotate(
             first_test=Case(
                 When(Q(pk=1), then=Value('noname')),
                 default=Subquery(tests[:1])
+            )
+        )
+        self.assert_tables(qs, User, Test)
+        self.assert_query_cached(qs, [self.user, self.admin])
+
+    def test_annotate_case_with_when(self):
+        tests = Test.objects.filter(owner=OuterRef('pk')).values('name')
+        qs = User.objects.annotate(
+            first_test=Case(
+                When(Q(pk=1), then=Subquery(tests[:1])),
+                default=Value('noname')
             )
         )
         self.assert_tables(qs, User, Test)

--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -6,7 +6,8 @@ from uuid import UUID
 
 from django.contrib.postgres.functions import TransactionNow
 from django.db import connections
-from django.db.models import Case, Exists, QuerySet, Subquery
+from django.db.models import Exists, QuerySet, Subquery
+from django.db.models.expressions import BaseExpression
 from django.db.models.functions import Now
 from django.db.models.sql import Query, AggregateQuery
 from django.db.models.sql.where import ExtraWhere, WhereNode, NothingNode
@@ -178,7 +179,7 @@ def _get_tables(db_alias, query):
             else:
                 tables.update(_get_tables(db_alias, _annotation.query))
 
-        def flatten(expression):
+        def flatten(expression: BaseExpression):
             """
             Recursively yield this expression and all subexpressions, in
             depth-first order.

--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -191,10 +191,7 @@ def _get_tables(db_alias, query):
             for expr in element.get_source_expressions():
                 if expr:
                     if hasattr(expr, 'flatten'):
-                        try:
-                            yield from flatten(expr)
-                        except AttributeError:
-                            yield expr
+                        yield from flatten(expr)
                     else:
                         yield expr
 

--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -174,7 +174,7 @@ def _flatten(expression: "BaseExpression"):
     for existence of flatten.
     """
     yield expression
-    for expr in element.get_source_expressions():
+    for expr in expression.get_source_expressions():
         if expr:
             if hasattr(expr, 'flatten'):
                 yield from _flatten(expr)

--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -2,18 +2,23 @@ import datetime
 from decimal import Decimal
 from hashlib import sha1
 from time import time
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from django.contrib.postgres.functions import TransactionNow
 from django.db import connections
 from django.db.models import Exists, QuerySet, Subquery
-from django.db.models.expressions import BaseExpression, RawSQL
+from django.db.models.expressions import RawSQL
 from django.db.models.functions import Now
 from django.db.models.sql import Query, AggregateQuery
 from django.db.models.sql.where import ExtraWhere, WhereNode, NothingNode
 
 from .settings import ITERABLES, cachalot_settings
 from .transaction import AtomicCache
+
+
+if TYPE_CHECKING:
+    from django.db.models.expressions import BaseExpression 
 
 
 class UncachableQuery(Exception):
@@ -160,6 +165,23 @@ def filter_cachable(tables):
     return tables
 
 
+def _flatten(expression: "BaseExpression"):
+    """
+    Recursively yield this expression and all subexpressions, in
+    depth-first order.
+
+    Taken from Django 3.2 as the previous Django versions don’t check
+    for existence of flatten.
+    """
+    yield expression
+    for expr in element.get_source_expressions():
+        if expr:
+            if hasattr(expr, 'flatten'):
+                yield from _flatten(expr)
+            else:
+                yield expr
+
+
 def _get_tables(db_alias, query):
     if query.select_for_update or (
             not cachalot_settings.CACHALOT_CACHE_RANDOM
@@ -173,35 +195,16 @@ def _get_tables(db_alias, query):
         tables = set(query.table_map)
         tables.add(query.get_meta().db_table)
 
-        def __update_annotated_subquery(_annotation: Subquery):
-            if hasattr(_annotation, "queryset"):
-                tables.update(_get_tables(db_alias, _annotation.queryset.query))
-            else:
-                tables.update(_get_tables(db_alias, _annotation.query))
-
-        def flatten(expression: BaseExpression):
-            """
-            Recursively yield this expression and all subexpressions, in
-            depth-first order.
-
-            Taken from Django 3.2 as the previous Django versions don’t check
-            for existence of flatten.
-            """
-            yield expression
-            for expr in element.get_source_expressions():
-                if expr:
-                    if hasattr(expr, 'flatten'):
-                        yield from flatten(expr)
-                    else:
-                        yield expr
-
         # Gets tables in subquery annotations.
         for annotation in query.annotations.values():
             if type(annotation) in UNCACHABLE_FUNCS:
                 raise UncachableQuery
-            for element in flatten(annotation):
+            for element in _flatten(annotation):
                 if isinstance(element, Subquery):
-                    __update_annotated_subquery(element)
+                    if hasattr(element, "queryset"):
+                        tables.update(_get_tables(db_alias, element.queryset.query))
+                    else:
+                        tables.update(_get_tables(db_alias, element.query))
                 elif isinstance(element, RawSQL):
                     sql = element.as_sql(None, None)[0].lower()
                     tables.update(_get_tables_from_sql(connections[db_alias], sql))

--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -180,16 +180,11 @@ def _get_tables(db_alias, query):
 
         # Gets tables in subquery annotations.
         for annotation in query.annotations.values():
-            if isinstance(annotation, Case):
-                for case in annotation.cases:
-                    for subquery in _find_subqueries_in_where(case.condition.children):
-                        tables.update(_get_tables(db_alias, subquery))
-                if isinstance(annotation.default, Subquery):
-                    __update_annotated_subquery(annotation.default)
-            elif isinstance(annotation, Subquery):
-                __update_annotated_subquery(annotation)
-            elif type(annotation) in UNCACHABLE_FUNCS:
+            if type(annotation) in UNCACHABLE_FUNCS:
                 raise UncachableQuery
+            for element in annotation.flatten():
+                if isinstance(element, Subquery):
+                    __update_annotated_subquery(element)
         # Gets tables in WHERE subqueries.
         for subquery in _find_subqueries_in_where(query.where.children):
             tables.update(_get_tables(db_alias, subquery))

--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -199,14 +199,14 @@ def _get_tables(db_alias, query):
         for annotation in query.annotations.values():
             if type(annotation) in UNCACHABLE_FUNCS:
                 raise UncachableQuery
-            for element in _flatten(annotation):
-                if isinstance(element, Subquery):
-                    if hasattr(element, "queryset"):
-                        tables.update(_get_tables(db_alias, element.queryset.query))
+            for expression in _flatten(annotation):
+                if isinstance(expression, Subquery):
+                    if hasattr(expression, "queryset"):
+                        tables.update(_get_tables(db_alias, expression.queryset.query))
                     else:
-                        tables.update(_get_tables(db_alias, element.query))
-                elif isinstance(element, RawSQL):
-                    sql = element.as_sql(None, None)[0].lower()
+                        tables.update(_get_tables(db_alias, expression.query))
+                elif isinstance(expression, RawSQL):
+                    sql = expression.as_sql(None, None)[0].lower()
                     tables.update(_get_tables_from_sql(connections[db_alias], sql))
         # Gets tables in WHERE subqueries.
         for subquery in _find_subqueries_in_where(query.where.children):

--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -203,7 +203,7 @@ def _get_tables(db_alias, query):
                 if isinstance(element, Subquery):
                     __update_annotated_subquery(element)
                 elif isinstance(element, RawSQL):
-                    sql = repr(element).lower()
+                    sql = element.as_sql(None, None)[0].lower()
                     tables.update(_get_tables_from_sql(connections[db_alias], sql))
         # Gets tables in WHERE subqueries.
         for subquery in _find_subqueries_in_where(query.where.children):

--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from django.contrib.postgres.functions import TransactionNow
 from django.db import connections
 from django.db.models import Exists, QuerySet, Subquery
-from django.db.models.expressions import BaseExpression
+from django.db.models.expressions import BaseExpression, RawSQL
 from django.db.models.functions import Now
 from django.db.models.sql import Query, AggregateQuery
 from django.db.models.sql.where import ExtraWhere, WhereNode, NothingNode
@@ -205,6 +205,9 @@ def _get_tables(db_alias, query):
             for element in flatten(annotation):
                 if isinstance(element, Subquery):
                     __update_annotated_subquery(element)
+                elif isinstance(element, RawSQL):
+                    sql = repr(element).lower()
+                    tables.update(_get_tables_from_sql(connections[db_alias], sql))
         # Gets tables in WHERE subqueries.
         for subquery in _find_subqueries_in_where(query.where.children):
             tables.update(_get_tables(db_alias, subquery))


### PR DESCRIPTION
https://github.com/django/django/blob/f42ccdd835e5b3f0914b5e6f87621c648136ea36/django/db/models/expressions.py#L370

Handle **annotation** cases:
- when `Subquery` is part of the `When`
- when `Coalesce` is used
- when `RawSQL` is used

[//]: # (Thanks for helping us out! Cache invalidation sucks, so your help is greatly appreciated!)

## Description
Expressions can contain multiple elements and all of them have to be checked.

[//]: # (What're you proposing?)


## Rationale
Ensure that all elements are checked for queries.

[//]: # (Why should we implement it?)
