### PR TITLE
Fix Django 3.2 default_app_config deprecation

### DIFF
--- a/cachalot/__init__.py
+++ b/cachalot/__init__.py
@@ -1,4 +1,7 @@
+from django import DJANGO_VERSION
+
 VERSION = (2, 4, 2)
 __version__ = ".".join(map(str, VERSION))
 
-default_app_config = "cachalot.apps.CachalotConfig"
+if DJANGO_VERSION < (3, 2):
+    default_app_config = "cachalot.apps.CachalotConfig"

--- a/cachalot/__init__.py
+++ b/cachalot/__init__.py
@@ -1,7 +1,10 @@
-from django import DJANGO_VERSION
-
 VERSION = (2, 4, 2)
 __version__ = ".".join(map(str, VERSION))
 
-if DJANGO_VERSION < (3, 2):
+try:
+    from django import VERSION as DJANGO_VERSION
+
+    if DJANGO_VERSION < (3, 2):
+        default_app_config = "cachalot.apps.CachalotConfig"
+except ImportError:
     default_app_config = "cachalot.apps.CachalotConfig"


### PR DESCRIPTION
[//]: # (Thanks for helping us out! Cache invalidation sucks, so your help is greatly appreciated!)

## Description

Django 3.2 default_app_config was deprecated since it's not needed


## Rationale

Deprecation