### PR TITLE
Include docs in sdist. Closes #201

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst LICENSE CHANGELOG.rst requirements.txt
 recursive-include cachalot *.json *.html
+graft docs


### PR DESCRIPTION
[//]: # (Thanks for helping us out! Cache invalidation sucks, so your help is greatly appreciated!)

## Description

[//]: Include docs in sdist


## Rationale

[//]: # Allow to include documentation in debian package
