### PR TITLE
Handle queryset implementations without lhs/rhs attribute

### DIFF
--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -135,10 +135,15 @@ def _find_subqueries_in_where(children):
         elif child_class is NothingNode:
             pass
         else:
-            rhs = _find_rhs_lhs_subquery(child.rhs)
+            try:
+                child_rhs = child.rhs
+                child_lhs = child.lhs
+            except AttributeError:
+                raise UncachableQuery
+            rhs = _find_rhs_lhs_subquery(child_rhs)
             if rhs is not None:
                 yield rhs
-            lhs = _find_rhs_lhs_subquery(child.lhs)
+            lhs = _find_rhs_lhs_subquery(child_lhs)
             if lhs is not None:
                 yield lhs
 


### PR DESCRIPTION
## Description

The `ExtraJoinRestriction` class used by [django-taggit](https://github.com/jazzband/django-taggit) lacks the attributes `rhs` and `lhs`. This causes a failure in cachalot's inspection.
Thus django projects cannot use django-taggit together with cachalot.

This proposal replaces cachalot's unconditional access to these attributes with a careful attribute access (returning `UncachableQuery` in case of failure).

## Rationale

I am not sure, whether django-taggit is to blame for not providing the `rhs` / `lhs` attributes in `ExtraJoinRestriction`.

But in general it should increase cachalot's robustness, if it could deal gracefully with non-conforming implementations. Thus carefully checking for implementation-specific attributes (instead of blindly assuming their existence) feels reasonable to me.

Closes: #121
