### PR TITLE
Add Python 3.10 Support (fixes #205)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         django-version: ['2.2', '3.1', '3.2']
 
     services:
       redis:
-        image: redis:6.0
+        image: redis:6
         ports:
           - 6379:6379
       postgres:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ What’s new in django-cachalot?
 -----
 
 - Handle queryset implementations without lhs/rhs attribute (#204)
+- Add Python 3.10 support (#206)
 - (Internal) Omit additional unnecessary code in coverage
 
 2.4.3

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet :: WWW/HTTP',
     ],
     license='BSD',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     py{36,37,38,39}-django2.2-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
     py{36,37,38,39}-django3.1-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
-    py{36,37,38,39}-django3.2-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
-    py{36,37,38,39}-djangomain-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
+    py{36,37,38,39,310}-django3.2-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
+    py{36,37,38,39,310}-djangomain-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
 
 [testenv]
 basepython =
@@ -11,6 +11,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
 deps =
     django2.2: Django>=2.2,<2.3
     django3.1: Django>=3.1,<3.2
@@ -45,6 +46,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [gh-actions:env]
 DJANGO =


### PR DESCRIPTION
[//]: # (Thanks for helping us out! Cache invalidation sucks, so your help is greatly appreciated!)

## Description

fixes #205

Add Python 3.10 support

[//]: # (What're you proposing?)


## Rationale

New version of Python! Currently, only Django 3.2 supports it.

[//]: # (Why should we implement it?)
