### PR TITLE
Update utils.py

### DIFF
--- a/cachalot/tests/read.py
+++ b/cachalot/tests/read.py
@@ -907,7 +907,7 @@ class ReadTestCase(TestUtilsMixin, TransactionTestCase):
     def test_explain(self):
         explain_kwargs = {}
         if self.is_sqlite:
-            expected = (r'\d+ 0 0 SCAN TABLE cachalot_test\n'
+            expected = (r'\d+ 0 0 SCAN cachalot_test\n'
                         r'\d+ 0 0 USE TEMP B-TREE FOR ORDER BY')
         elif self.is_mysql:
             if self.django_version < (3, 1):

--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -217,7 +217,8 @@ def _get_tables(db_alias, query, compiler=False):
 
         # Gets all tables already found by the ORM.
         tables = set(query.table_map)
-        tables.add(query.get_meta().db_table)
+        if query.get_meta():
+            tables.add(query.get_meta().db_table)
 
         # Gets tables in subquery annotations.
         for annotation in query.annotations.values():

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py{38,39,310}-djangomain-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
 
 [testenv]
+passenv = *
 basepython =
     py37: python3.7
     py38: python3.8


### PR DESCRIPTION
verify get_meta isn't none before requesting db_table

## Description
Patch to check that "query.get_meta()" is not None before getting db_table attribue.

## Rationale
Using:
Django: 4.1.6
django-cachalot: 2.5.2
psycopg2: 2.9.5

During Model.validate_constraints() on new object save, I'm getting an "AttributeError" exception in _get_tables of utils.py at:
tables.add(query.get_meta().db_table); specifically when checking a FloatField constraint is greater than 0.  

The issue is query.get_meta() is returning None, which doesn't have a db_table attribute.  This patch checks for None before getting db_table.

The issue *does not* occur on Django 4.0.9. 

