### PR TITLE
Andrew wang/dj4.2 Improve assertNumQueries by filtering out transaction-related queries

### DIFF
--- a/cachalot/tests/read.py
+++ b/cachalot/tests/read.py
@@ -21,7 +21,7 @@ from cachalot.cache import cachalot_caches
 from ..settings import cachalot_settings
 from ..utils import UncachableQuery
 from .models import Test, TestChild, TestParent, UnmanagedModel
-from .test_utils import TestUtilsMixin
+from .test_utils import TestUtilsMixin, FilteredTransactionTestCase
 
 from .tests_decorators import all_final_sql_checks, with_final_sql_check, no_final_sql_check
 
@@ -36,7 +36,7 @@ def is_field_available(name):
     return name in fields
 
 
-class ReadTestCase(TestUtilsMixin, TransactionTestCase):
+class ReadTestCase(TestUtilsMixin, FilteredTransactionTestCase):
     """
     Tests if every SQL request that only reads data is cached.
 
@@ -896,9 +896,7 @@ class ReadTestCase(TestUtilsMixin, TransactionTestCase):
         self.assert_query_cached(qs, [self.t2, self.t1])
 
     def test_table_inheritance(self):
-        with self.assertNumQueries(
-            3 if self.is_sqlite else (4 if DJANGO_VERSION >= (4, 2) else 2)
-        ):
+        with self.assertNumQueries(2):
             t_child = TestChild.objects.create(name='test_child')
 
         with self.assertNumQueries(1):

--- a/cachalot/tests/read.py
+++ b/cachalot/tests/read.py
@@ -816,21 +816,21 @@ class ReadTestCase(TestUtilsMixin, FilteredTransactionTestCase):
         with self.assertRaises(TransactionManagementError):
             list(Test.objects.select_for_update())
 
-        with self.assertNumQueries(3 if DJANGO_VERSION >= (4, 2) else 1):
+        with self.assertNumQueries(1):
             with transaction.atomic():
                 data1 = list(Test.objects.select_for_update())
                 self.assertListEqual(data1, [self.t1, self.t2])
                 self.assertListEqual([t.name for t in data1],
                                      ['test1', 'test2'])
 
-        with self.assertNumQueries(3 if DJANGO_VERSION >= (4, 2) else 1):
+        with self.assertNumQueries(1):
             with transaction.atomic():
                 data2 = list(Test.objects.select_for_update())
                 self.assertListEqual(data2, [self.t1, self.t2])
                 self.assertListEqual([t.name for t in data2],
                                      ['test1', 'test2'])
 
-        with self.assertNumQueries(4 if DJANGO_VERSION >= (4, 2) else 2):
+        with self.assertNumQueries(2):
             with transaction.atomic():
                 data3 = list(Test.objects.select_for_update())
                 data4 = list(Test.objects.select_for_update())

--- a/cachalot/tests/test_utils.py
+++ b/cachalot/tests/test_utils.py
@@ -1,5 +1,8 @@
 from django.core.management.color import no_style
-from django.db import connection, transaction
+from django.db import DEFAULT_DB_ALIAS, connection, connections, transaction
+
+from django.test import TransactionTestCase
+from django.test.utils import CaptureQueriesContext
 
 from ..utils import _get_tables
 from .models import PostgresModel
@@ -57,3 +60,61 @@ class TestUtilsMixin:
         assert_function(data2, data1)
         if result is not None:
             assert_function(data2, result)
+
+class FilteredTransactionTestCase(TransactionTestCase):
+    """
+    TransactionTestCase with assertNumQueries that ignores BEGIN, COMMIT and ROLLBACK
+    queries.
+    """
+    def assertNumQueries(self, num, func=None, *args, using=DEFAULT_DB_ALIAS, **kwargs):
+        conn = connections[using]
+
+        context = FilteredAssertNumQueriesContext(self, num, conn)
+        if func is None:
+            return context
+
+        with context:
+            func(*args, **kwargs)
+
+
+class FilteredAssertNumQueriesContext(CaptureQueriesContext):
+    """
+    Capture queries and assert their number ignoring BEGIN, COMMIT and ROLLBACK queries.
+    """
+    EXCLUDE = ('BEGIN', 'COMMIT', 'ROLLBACK')
+
+    def __init__(self, test_case, num, connection):
+        self.test_case = test_case
+        self.num = num
+        super().__init__(connection)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if exc_type is not None:
+            return
+
+        filtered_queries = []
+        excluded_queries = []
+        for q in self.captured_queries:
+            if q['sql'].upper() not in self.EXCLUDE:
+                filtered_queries.append(q)
+            else:
+                excluded_queries.append(q)
+
+        executed = len(filtered_queries)
+
+        self.test_case.assertEqual(
+            executed,
+            self.num,
+            f"\n{executed} queries executed, {self.num} expected\n" +
+            "\nCaptured queries were:\n" +
+            "".join(
+                f"{i}. {query['sql']}\n"
+                for i, query in enumerate(filtered_queries, start=1)
+            ) +
+            "\nCaptured queries, that were excluded:\n" +
+            "".join(
+                f"{i}. {query['sql']}\n"
+                for i, query in enumerate(excluded_queries, start=1)
+            )
+        )

--- a/cachalot/tests/transaction.py
+++ b/cachalot/tests/transaction.py
@@ -1,20 +1,17 @@
 from cachalot.transaction import AtomicCache
 
-from django import VERSION as DJANGO_VERSION
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.db import transaction, connection, IntegrityError
-from django.test import SimpleTestCase, TransactionTestCase, skipUnlessDBFeature
+from django.test import SimpleTestCase, skipUnlessDBFeature
 
 from .models import Test
-from .test_utils import TestUtilsMixin
+from .test_utils import TestUtilsMixin, FilteredTransactionTestCase
 
 
-class AtomicTestCase(TestUtilsMixin, TransactionTestCase):
+class AtomicTestCase(TestUtilsMixin, FilteredTransactionTestCase):
     def test_successful_read_atomic(self):
-        with self.assertNumQueries(
-            2 if self.is_sqlite else (3 if DJANGO_VERSION >= (4, 2) else 1)
-        ):
+        with self.assertNumQueries(1):
             with transaction.atomic():
                 data1 = list(Test.objects.all())
         self.assertListEqual(data1, [])
@@ -24,9 +21,7 @@ class AtomicTestCase(TestUtilsMixin, TransactionTestCase):
         self.assertListEqual(data2, [])
 
     def test_unsuccessful_read_atomic(self):
-        with self.assertNumQueries(
-            2 if self.is_sqlite else (3 if DJANGO_VERSION >= (4, 2) else 1)
-        ):
+        with self.assertNumQueries(1):
             try:
                 with transaction.atomic():
                     data1 = list(Test.objects.all())
@@ -44,27 +39,21 @@ class AtomicTestCase(TestUtilsMixin, TransactionTestCase):
             data1 = list(Test.objects.all())
         self.assertListEqual(data1, [])
 
-        with self.assertNumQueries(
-            2 if self.is_sqlite else (3 if DJANGO_VERSION >= (4, 2) else 1)
-        ):
+        with self.assertNumQueries(1):
             with transaction.atomic():
                 t1 = Test.objects.create(name='test1')
         with self.assertNumQueries(1):
             data2 = list(Test.objects.all())
         self.assertListEqual(data2, [t1])
 
-        with self.assertNumQueries(
-            2 if self.is_sqlite else (3 if DJANGO_VERSION >= (4, 2) else 1)
-        ):
+        with self.assertNumQueries(1):
             with transaction.atomic():
                 t2 = Test.objects.create(name='test2')
         with self.assertNumQueries(1):
             data3 = list(Test.objects.all())
         self.assertListEqual(data3, [t1, t2])
 
-        with self.assertNumQueries(
-            4 if self.is_sqlite else (5 if DJANGO_VERSION >= (4, 2) else 3)
-        ):
+        with self.assertNumQueries(3):
             with transaction.atomic():
                 data4 = list(Test.objects.all())
                 t3 = Test.objects.create(name='test3')
@@ -79,9 +68,7 @@ class AtomicTestCase(TestUtilsMixin, TransactionTestCase):
             data1 = list(Test.objects.all())
         self.assertListEqual(data1, [])
 
-        with self.assertNumQueries(
-            2 if self.is_sqlite else (3 if DJANGO_VERSION >= (4, 2) else 1)
-        ):
+        with self.assertNumQueries(1):
             try:
                 with transaction.atomic():
                     Test.objects.create(name='test')
@@ -96,9 +83,7 @@ class AtomicTestCase(TestUtilsMixin, TransactionTestCase):
                 Test.objects.get(name='test')
 
     def test_cache_inside_atomic(self):
-        with self.assertNumQueries(
-            2 if self.is_sqlite else (3 if DJANGO_VERSION >= (4, 2) else 1)
-        ):
+        with self.assertNumQueries(1):
             with transaction.atomic():
                 data1 = list(Test.objects.all())
                 data2 = list(Test.objects.all())
@@ -106,9 +91,7 @@ class AtomicTestCase(TestUtilsMixin, TransactionTestCase):
         self.assertListEqual(data2, [])
 
     def test_invalidation_inside_atomic(self):
-        with self.assertNumQueries(
-            4 if self.is_sqlite else (5 if DJANGO_VERSION >= (4, 2) else 3)
-        ):
+        with self.assertNumQueries(3):
             with transaction.atomic():
                 data1 = list(Test.objects.all())
                 t = Test.objects.create(name='test')
@@ -117,9 +100,7 @@ class AtomicTestCase(TestUtilsMixin, TransactionTestCase):
         self.assertListEqual(data2, [t])
 
     def test_successful_nested_read_atomic(self):
-        with self.assertNumQueries(
-            7 if self.is_sqlite else (8 if DJANGO_VERSION >= (4, 2) else 6)
-        ):
+        with self.assertNumQueries(6):
             with transaction.atomic():
                 list(Test.objects.all())
                 with transaction.atomic():
@@ -134,9 +115,7 @@ class AtomicTestCase(TestUtilsMixin, TransactionTestCase):
             list(User.objects.all())
 
     def test_unsuccessful_nested_read_atomic(self):
-        with self.assertNumQueries(
-            6 if self.is_sqlite else (7 if DJANGO_VERSION >= (4, 2) else 5)
-        ):
+        with self.assertNumQueries(5):
             with transaction.atomic():
                 try:
                     with transaction.atomic():
@@ -149,9 +128,7 @@ class AtomicTestCase(TestUtilsMixin, TransactionTestCase):
                     list(Test.objects.all())
 
     def test_successful_nested_write_atomic(self):
-        with self.assertNumQueries(
-            13 if self.is_sqlite else (14 if DJANGO_VERSION >= (4, 2) else 12)
-        ):
+        with self.assertNumQueries(12):
             with transaction.atomic():
                 t1 = Test.objects.create(name='test1')
                 with transaction.atomic():
@@ -168,9 +145,7 @@ class AtomicTestCase(TestUtilsMixin, TransactionTestCase):
         self.assertListEqual(data3, [t1, t2, t3, t4])
 
     def test_unsuccessful_nested_write_atomic(self):
-        with self.assertNumQueries(
-            16 if self.is_sqlite else (17 if DJANGO_VERSION >= (4, 2) else 15)
-        ):
+        with self.assertNumQueries(15):
             with transaction.atomic():
                 t1 = Test.objects.create(name='test1')
                 try:


### PR DESCRIPTION
[//]: # (Thanks for helping us out! Cache invalidation sucks, so your help is greatly appreciated!)

## Description
This pull request introduces a new class, FilteredTransactionTestCase, which extends Django's TransactionTestCase and provides an improved version of assertNumQueries that filters out transaction-related queries such as BEGIN, COMMIT, and ROLLBACK. This change helps to make the test results more accurate and focused on the actual queries being executed by the application code as proposed in the pull request #229 . The pull request also modifies the existing test cases to use the new FilteredTransactionTestCase class.

## Rationale

The current implementation of assertNumQueries in Django counts all queries executed within the context, including transaction-related queries. This can lead to discrepancies in the expected number of queries and the actual number of queries executed by the application code. By filtering out transaction-related queries, we can ensure that the tests are more focused on the application logic and provide more accurate results. This change will improve the reliability of the test suite and make it easier to understand the performance of the application.

The changes made in this pull request are based on the following modifications:

- Added a new class FilteredTransactionTestCase in test_utils.py which extends TransactionTestCase and provides a custom implementation of assertNumQueries.
- Added a new class FilteredAssertNumQueriesContext in test_utils.py which extends CaptureQueriesContext and filters out transaction-related queries from the captured queries.
- Replaced TransactionTestCase with FilteredTransactionTestCase in read.py, thread_safety.py, transaction.py, and write.py. This change ensures that the improved version of assertNumQueries is used in all test cases.
- Updated the expected number of queries in the tests to account for the filtered transaction-related queries.
