### PR TITLE
fix: Catch ModuleNotFoundError on cache retrieve

### DIFF
--- a/cachalot/monkey_patch.py
+++ b/cachalot/monkey_patch.py
@@ -44,7 +44,7 @@ def _get_result_or_execute_query(execute_query_func, cache,
                                  cache_key, table_cache_keys):
     try:
         data = cache.get_many(table_cache_keys + [cache_key])
-    except KeyError:
+    except (KeyError, ModuleNotFoundError):
         data = None
 
     new_table_cache_keys = set(table_cache_keys)


### PR DESCRIPTION
Catch ModuleNotFoundError for error cases due to pickle serialization of old classpath

## Description
I propose a fix for the issue I wrote: https://github.com/noripyt/django-cachalot/issues/257

As for previous KeyError catching implementation, I don't know how to test it. Do you have any idea?
