### PR TITLE
Add support for testing against the builtin redis backend

### DIFF
--- a/cachalot/settings.py
+++ b/cachalot/settings.py
@@ -30,6 +30,7 @@ SUPPORTED_CACHE_BACKENDS = {
     'django.core.cache.backends.dummy.DummyCache',
     'django.core.cache.backends.locmem.LocMemCache',
     'django.core.cache.backends.filebased.FileBasedCache',
+    'django.core.cache.backends.redis.RedisCache',
     'django_redis.cache.RedisCache',
     'django.core.cache.backends.memcached.MemcachedCache',
     'django.core.cache.backends.memcached.PyLibMCCache',

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -9,6 +9,8 @@ Requirements
 - a cache configured as ``'default'`` with one of these backends:
 
   - `django-redis <https://github.com/niwinz/django-redis>`_
+  - `redis <https://docs.djangoproject.com/en/dev/topics/cache/#redis>`_
+    (requires Django >= 4)
   - `memcached <https://docs.djangoproject.com/en/dev/topics/cache/#memcached>`_
     (using either python-memcached or pylibmc)
   - `filebased <https://docs.djangoproject.com/en/dev/topics/cache/#filesystem-caching>`_

--- a/settings.py
+++ b/settings.py
@@ -73,6 +73,18 @@ CACHES = {
 }
 
 try:
+    from django.core.cache.backends.redis import RedisCache
+except ImportError:
+    pass
+else:
+    CACHES['builtin_redis']= {
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+        # Make sure to use a different redis database to avoid conflicts with the other
+        # redis cache backend.
+        'LOCATION': 'redis://127.0.0.1:6379/1',
+    }
+
+try:
     import pylibmc
 except ImportError:
     pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
     py{37,38,39,310}-django3.2-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
-    py{38,39,310}-django4.1-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
-    py{38,39,310,312}-django4.2-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
-    py{310,311,312}-django5.0-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
-    py{310,311,312}-djangomain-{sqlite3,postgresql,mysql}-{redis,memcached,pylibmc,locmem,filebased},
+    py{38,39,310}-django4.1-{sqlite3,postgresql,mysql}-{builtin_redis,redis,memcached,pylibmc,locmem,filebased},
+    py{38,39,310,312}-django4.2-{sqlite3,postgresql,mysql}-{builtin_redis,redis,memcached,pylibmc,locmem,filebased},
+    py{310,311,312}-django5.0-{sqlite3,postgresql,mysql}-{builtin_redis,redis,memcached,pylibmc,locmem,filebased},
+    py{310,311,312}-djangomain-{sqlite3,postgresql,mysql}-{builtin_redis,redis,memcached,pylibmc,locmem,filebased},
 
 [testenv]
 passenv = *
@@ -35,14 +35,15 @@ deps =
     beautifulsoup4
     coverage
 setenv =
-    sqlite3:    DB_ENGINE=sqlite3
-    postgresql: DB_ENGINE=postgresql
-    mysql:      DB_ENGINE=mysql
-    locmem:     CACHE_BACKEND=locmem
-    filebased:  CACHE_BACKEND=filebased
-    redis:      CACHE_BACKEND=redis
-    memcached:  CACHE_BACKEND=memcached
-    pylibmc:    CACHE_BACKEND=pylibmc
+    sqlite3:       DB_ENGINE=sqlite3
+    postgresql:    DB_ENGINE=postgresql
+    mysql:         DB_ENGINE=mysql
+    locmem:        CACHE_BACKEND=locmem
+    filebased:     CACHE_BACKEND=filebased
+    redis:         CACHE_BACKEND=redis
+    builtin_redis: CACHE_BACKEND=builtin_redis
+    memcached:     CACHE_BACKEND=memcached
+    pylibmc:       CACHE_BACKEND=pylibmc
 commands =
     coverage run -a --source=cachalot ./runtests.py
 


### PR DESCRIPTION
Closes #209.
Closes #222.

## Description

Add support to the test matrix for testing against Django's built in redis cache backend.

## Rationale

Fewer dependencies :)