### PR TITLE
Add support for caching queries with enum filters

### DIFF
--- a/cachalot/tests/migrations/0001_initial.py
+++ b/cachalot/tests/migrations/0001_initial.py
@@ -51,6 +51,8 @@ class Migration(migrations.Migration):
                 ('permission', models.ForeignKey(blank=True, to='auth.Permission', null=True, on_delete=models.PROTECT)),
                 ('a_float', models.FloatField(null=True, blank=True)),
                 ('a_decimal', models.DecimalField(null=True, blank=True, max_digits=5, decimal_places=2)),
+                ('a_choice', models.CharField(choices=[("foo","foo"), ("bar","bar")], null=True, max_length=3)),
+                ('a_dict_choice', models.CharField(choices=[("foo","foo"), ("bar","bar")], null=True, max_length=3)),
                 ('bin', models.BinaryField(null=True, blank=True)),
                 ('ip', models.GenericIPAddressField(null=True, blank=True)),
                 ('duration', models.DurationField(null=True, blank=True)),

--- a/cachalot/tests/models.py
+++ b/cachalot/tests/models.py
@@ -6,9 +6,13 @@ from django.contrib.postgres.fields import (
     DateTimeRangeField)
 from django.db.models import (
     Model, CharField, ForeignKey, BooleanField, DateField, DateTimeField,
-    ManyToManyField, BinaryField, IntegerField, GenericIPAddressField,
+    ManyToManyField, BinaryField, IntegerField, GenericIPAddressField, TextChoices,
     FloatField, DecimalField, DurationField, UUIDField, SET_NULL, PROTECT)
 
+
+class SomeChoices(TextChoices):
+    foo = 'foo'
+    bar = 'bar'
 
 class Test(Model):
     name = CharField(max_length=20)
@@ -25,6 +29,7 @@ class Test(Model):
     a_float = FloatField(null=True, blank=True)
     a_decimal = DecimalField(null=True, blank=True,
                              max_digits=5, decimal_places=2)
+    a_choice = CharField(max_length=3, choices=SomeChoices.choices, null=True)
     bin = BinaryField(null=True, blank=True)
     ip = GenericIPAddressField(null=True, blank=True)
     duration = DurationField(null=True, blank=True)

--- a/cachalot/tests/read.py
+++ b/cachalot/tests/read.py
@@ -20,7 +20,7 @@ from pytz import UTC
 from cachalot.cache import cachalot_caches
 from ..settings import cachalot_settings
 from ..utils import UncachableQuery
-from .models import Test, TestChild, TestParent, UnmanagedModel
+from .models import SomeChoices, Test, TestChild, TestParent, UnmanagedModel
 from .test_utils import TestUtilsMixin, FilteredTransactionTestCase
 
 from .tests_decorators import all_final_sql_checks, with_final_sql_check, no_final_sql_check
@@ -242,6 +242,11 @@ class ReadTestCase(TestUtilsMixin, FilteredTransactionTestCase):
         self.assert_tables(qs, Test, User, User.user_permissions.through,
                            Permission, ContentType)
         self.assert_query_cached(qs, [self.t1])
+
+    def test_django_enums(self):
+        t = Test.objects.create(name='test1', a_choice=SomeChoices.foo)
+        qs = Test.objects.filter(a_choice=SomeChoices.foo)
+        self.assert_query_cached(qs, [t])
 
     def test_iterator(self):
         with self.assertNumQueries(1):

--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from django.contrib.postgres.functions import TransactionNow
 from django.db.models import Exists, QuerySet, Subquery
+from django.db.models.enums import Choices
 from django.db.models.expressions import RawSQL
 from django.db.models.functions import Now
 from django.db.models.sql import Query, AggregateQuery
@@ -80,6 +81,11 @@ def check_parameter_types(params):
                 check_parameter_types(p)
             elif cl is dict:
                 check_parameter_types(p.items())
+            elif issubclass(cl, Choices):
+                # Handle the case where a parameter from a Choices field is passed.
+                # Django Choices use enum.unique() so the values are guaranteed to be unique.
+                # Dereference the true "value" and verify that it is cachable.
+                check_parameter_types([p.value])
             else:
                 raise UncachableQuery
 


### PR DESCRIPTION
Fixes #218 

## Description
This should make queries that filter on enum values stop raising `UncachableQuery` by inferring their real type. See #218 for an example of a query that's fixed by this PR.

## Rationale
Cache everything? :)